### PR TITLE
Fixed build for 0.7 and 1.0 (added Libdl)

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,6 @@
 using Compat
+using Libdl 
+
 if Compat.Sys.iswindows()
     flags = ["-m$(Sys.WORD_SIZE)","-fdefault-real-8","-ffixed-form","-shared","-O3"]
 else


### PR DESCRIPTION
Added `using Libdl` in `build.jl` to fix the following error

```julia
ERROR: LoadError: UndefVarError: Libdl not defined
Stacktrace:
 [1] top-level scope at none:0
 [2] include at ./boot.jl:317 [inlined]
 [3] include_relative(::Module, ::String) at ./loading.jl:1038
 [4] include(::Module, ::String) at ./sysimg.jl:29
 [5] include(::String) at ./client.jl:388
 [6] top-level scope at none:0
in expression starting at /home/abisen/shared/GLMNet.jl/deps/build.jl:8
```